### PR TITLE
[XTG-323] Edit and Delete Leaderboard and Achievement

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,10 +1,11 @@
 version: 0.2
 
 env:
+  shell: bash
   git-credential-helper: yes
-  parameter-store:
-    DOCKER_HUB_USER: '/devops/shared/DOCKER_HUB_USER'
-    DOCKER_HUB_PASSWORD: '/devops/shared/DOCKER_HUB_PASSWORD'
+  variables:
+    AWS_ENV_PATH: '/gameshq/frontend'
+    AWS_REGION: 'us-east-1'
 
 phases:
   install:
@@ -13,25 +14,20 @@ phases:
     commands:
       - n 16
       - npm update -g npm
+      - npm install -g yarn
       - aws --version
       - node -v
-  pre_build:
-    commands:
-      - export APP_BUILD_VERSION=${CODEBUILD_RESOLVED_SOURCE_VERSION}__$(date -u '+%Y-%m-%dT%T+00:00')
-      - echo $APP_BUILD_VERSION > ./src/.version
-      - cat ./src/.version
-      - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $DOCKER_REPOSITORY_URI
-      - IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - yarn -v
+      - yarn install --frozen-lockfile --production=false
+      - wget https://github.com/Droplr/aws-env/raw/master/bin/aws-env-linux-amd64 -O aws-env
+      - chmod +x aws-env
+
   build:
     commands:
-      - echo $DOCKER_HUB_PASSWORD | docker login --username $DOCKER_HUB_USER --password-stdin
-      - docker build -t $DOCKER_REPOSITORY_URI:latest .
-      - docker tag $DOCKER_REPOSITORY_URI:latest $DOCKER_REPOSITORY_URI:$IMAGE_TAG
+      - eval $(./aws-env --recursive)
+      - yarn install --frozen-lockfile --production=false
+      - NODE_ENV=production yarn build
+
   post_build:
     commands:
-      - docker push $DOCKER_REPOSITORY_URI:latest
-      - docker push $DOCKER_REPOSITORY_URI:$IMAGE_TAG
-      - printf '[{"name":"%s","imageUri":"%s"}]' $CONTAINER_NAME $DOCKER_REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
-artifacts:
-  files:
-    - imagedefinitions.json
+      - aws s3 sync build/. s3://$FRONTEND_BUCKET

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ export const App = () => {
           }
         />
         <Route
-          path="/achievements/:achievementId"
+          path="/games/achievements/:achievementId"
           element={
             <ProtectedRoute>
               <AppMenu>
@@ -79,7 +79,7 @@ export const App = () => {
           }
         />
         <Route
-          path="/leaderboards/:leaderboardId"
+          path="/games/leaderboards/:leaderboardId"
           element={
             <ProtectedRoute>
               <AppMenu>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ import HomePage from "./pages/HomePage";
 // import { UnauthorizedPage } from "./pages/UnauthorizedPage";
 import { ProtectedRoute } from "./ProtectedRoute";
 import { AppMenu } from "./AppMenu";
+import AchievementsPage from "./pages/AchievementsPage";
+import LeaderboardsPage from "./pages/LeaderboardsPage";
 
 export const App = () => {
   // if (isDoingInitialLoading) {
@@ -62,6 +64,26 @@ export const App = () => {
             <ProtectedRoute>
               <AppMenu>
                 <GameEditorPage />
+              </AppMenu>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/achievements/:achievementId"
+          element={
+            <ProtectedRoute>
+              <AppMenu>
+                <AchievementsPage />
+              </AppMenu>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/leaderboards/:leaderboardId"
+          element={
+            <ProtectedRoute>
+              <AppMenu>
+                <LeaderboardsPage />
               </AppMenu>
             </ProtectedRoute>
           }

--- a/src/api/acheivements.ts
+++ b/src/api/acheivements.ts
@@ -3,7 +3,7 @@ import { gamesHqUrl, getAxiosInstance } from "./utils";
 export const getAchievements = async (gameTypeId: number) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/achievements`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/acheivements`;
   const response = await axios.get(endpoint);
   const achievements = response.data;
   
@@ -13,7 +13,7 @@ export const getAchievements = async (gameTypeId: number) => {
 export const getAchievement = async (gameTypeId: number, achievementId: number) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/achievements/${achievementId}`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/acheivements/${achievementId}`;
   const response = await axios.get(endpoint);
   const acheivement = response.data.game as IGameType;
 
@@ -23,13 +23,13 @@ export const getAchievement = async (gameTypeId: number, achievementId: number) 
 export const upsertAchievement = async (data: IAchievement) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${data._gameTypeId}/achievements/${data.id}`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${data._gameTypeId}/acheivements/${data.id}`;
   await axios.post(endpoint, data);
 };
 
 export const deleteAcheivement = async (gameTypeId: number, achievementId: number) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/achievements/${achievementId}`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/acheivements/${achievementId}`;
   await axios.delete(endpoint);
 };

--- a/src/api/acheivements.ts
+++ b/src/api/acheivements.ts
@@ -1,0 +1,35 @@
+import { gamesHqUrl, getAxiosInstance } from "./utils";
+
+export const getAchievements = async (gameTypeId: number) => {
+  const axios = await getAxiosInstance();
+
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/acheivements`;
+  const response = await axios.get(endpoint);
+  const achievements = response.data;
+  
+  return achievements;
+};
+
+export const getAchievement = async (gameTypeId: number, achievementId: number) => {
+  const axios = await getAxiosInstance();
+
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/acheivements/${achievementId}`;
+  const response = await axios.get(endpoint);
+  const acheivement = response.data.game as IGameType;
+
+  return acheivement;
+};
+
+export const upsertAchievement = async (data: IAchievement) => {
+  const axios = await getAxiosInstance();
+
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${data._gameTypeId}/acheivements/${data.id}`;
+  await axios.post(endpoint, data);
+};
+
+export const deleteAcheivement = async (gameTypeId: number, achievementId: number) => {
+  const axios = await getAxiosInstance();
+
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/acheivements/${achievementId}`;
+  await axios.delete(endpoint);
+};

--- a/src/api/acheivements.ts
+++ b/src/api/acheivements.ts
@@ -3,7 +3,7 @@ import { gamesHqUrl, getAxiosInstance } from "./utils";
 export const getAchievements = async (gameTypeId: number) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/acheivements`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/achievements`;
   const response = await axios.get(endpoint);
   const achievements = response.data;
   
@@ -13,7 +13,7 @@ export const getAchievements = async (gameTypeId: number) => {
 export const getAchievement = async (gameTypeId: number, achievementId: number) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/acheivements/${achievementId}`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/achievements/${achievementId}`;
   const response = await axios.get(endpoint);
   const acheivement = response.data.game as IGameType;
 
@@ -23,13 +23,13 @@ export const getAchievement = async (gameTypeId: number, achievementId: number) 
 export const upsertAchievement = async (data: IAchievement) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${data._gameTypeId}/acheivements/${data.id}`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${data._gameTypeId}/achievements/${data.id}`;
   await axios.post(endpoint, data);
 };
 
 export const deleteAcheivement = async (gameTypeId: number, achievementId: number) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/acheivements/${achievementId}`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/achievements/${achievementId}`;
   await axios.delete(endpoint);
 };

--- a/src/api/achievements.ts
+++ b/src/api/achievements.ts
@@ -23,7 +23,7 @@ export const getAchievement = async (gameTypeId: number, achievementId: number) 
 export const upsertAchievement = async (data: IAchievement) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${data._gameTypeId}/achievements/${data.id}`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${data._gameTypeId}/achievements`;
   await axios.post(endpoint, data);
 };
 

--- a/src/api/achievements.ts
+++ b/src/api/achievements.ts
@@ -3,7 +3,7 @@ import { gamesHqUrl, getAxiosInstance } from "./utils";
 export const getAchievements = async (gameTypeId: number) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/acheivements`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/achievements`;
   const response = await axios.get(endpoint);
   const achievements = response.data;
   
@@ -13,7 +13,7 @@ export const getAchievements = async (gameTypeId: number) => {
 export const getAchievement = async (gameTypeId: number, achievementId: number) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/acheivements/${achievementId}`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/achievements/${achievementId}`;
   const response = await axios.get(endpoint);
   const acheivement = response.data.game as IGameType;
 
@@ -23,13 +23,13 @@ export const getAchievement = async (gameTypeId: number, achievementId: number) 
 export const upsertAchievement = async (data: IAchievement) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${data._gameTypeId}/acheivements/${data.id}`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${data._gameTypeId}/achievements/${data.id}`;
   await axios.post(endpoint, data);
 };
 
 export const deleteAcheivement = async (gameTypeId: number, achievementId: number) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/acheivements/${achievementId}`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/achievements/${achievementId}`;
   await axios.delete(endpoint);
 };

--- a/src/api/leaderboards.ts
+++ b/src/api/leaderboards.ts
@@ -5,7 +5,7 @@ export const getGameTypeLeaderboards = async (gameTypeId: number) => {
 
   const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/leaderboards`;
   const response = await axios.get(endpoint);
-  const leaderboards = response.data.games as IGameType[];
+  const leaderboards = response.data.games as ILeaderboard[];
 
   return leaderboards;
 };

--- a/src/api/leaderboards.ts
+++ b/src/api/leaderboards.ts
@@ -20,10 +20,10 @@ export const getLeaderboard = async (gameTypeId: number, leaderboardId: number) 
   return game;
 };
 
-export const upsertLeaderboard = async (gameTypeId: number, data: ILeaderboard) => {
+export const upsertLeaderboard = async (data: ILeaderboard) => {
   const axios = await getAxiosInstance();
 
-  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/leaderboards/${data.id}`;
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${data._gameTypeId}/leaderboards`;
   await axios.post(endpoint, data);
 };
 

--- a/src/api/leaderboards.ts
+++ b/src/api/leaderboards.ts
@@ -1,0 +1,35 @@
+import { gamesHqUrl, getAxiosInstance } from "./utils";
+
+export const getGameTypeLeaderboards = async (gameTypeId: number) => {
+  const axios = await getAxiosInstance();
+
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/leaderboards`;
+  const response = await axios.get(endpoint);
+  const leaderboards = response.data.games as IGameType[];
+
+  return leaderboards;
+};
+
+export const getLeaderboard = async (gameTypeId: number, leaderboardId: number) => {
+  const axios = await getAxiosInstance();
+
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/leaderboards/${leaderboardId}`;
+  const response = await axios.get(endpoint);
+  const game = response.data.game as IGameType;
+
+  return game;
+};
+
+export const upsertLeaderboard = async (gameTypeId: number, data: ILeaderboard) => {
+  const axios = await getAxiosInstance();
+
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/leaderboards/${data.id}`;
+  await axios.post(endpoint, data);
+};
+
+export const deleteLeaderboard = async (gameTypeId: number, leaderboardId: number) => {
+  const axios = await getAxiosInstance();
+
+  const endpoint = gamesHqUrl + `/dashboard/game-dev/games/${gameTypeId}/leaderboards/${leaderboardId}`;
+  await axios.delete(endpoint);
+};

--- a/src/pages/AchievementsPage.tsx
+++ b/src/pages/AchievementsPage.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { getAchievement } from "../api/achievements";
+
+const AchievementsPage =() => {
+    const achievement = useState<IAchievement | undefined>();
+    useEffect(() => {
+        async function fetchAchievement() {
+            const achievement = await getAchievement(1,2); // TODO GET FROM PARAM
+        }
+
+        fetchAchievement();
+    }, []);
+
+    return (
+        <div>
+            <h2 className="text-2xl font-bold italic font-sans mb-8">
+                ACHIEVEMENTS
+            </h2>
+
+            {achievement ? (
+                <>
+                    <table>
+                        <tr></tr>
+                    </table>
+                </>
+            ) : (
+                <p>Loading</p>
+            )}
+        </div>
+    );
+};
+
+export default AchievementsPage;

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -227,7 +227,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
             </tr>
             {currentGameType?._leaderboards?.map(
               (leaderboard: ILeaderboard) => (
-                <tr>
+                <tr key={`leaderboard${leaderboard.id}`}>
                   <td className="border px-8 py-4" ><Link to={`/games/leaderboards/${leaderboard.id}`}>{leaderboard.id}</Link></td>
                   <td className="border px-8 py-4"><Link to={`/games/leaderboards/${leaderboard.id}`}>{leaderboard.name}</Link></td>
                   <td className="border px-8 py-4">
@@ -281,7 +281,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
               <th className="bg-gray-100 border text-left px-8 py-4">Edit</th>
             </tr>
               {achievements?.map((achievement => 
-                <tr>
+                <tr key={`achievement${achievement.id}`}>
                     <td className="border px-8 py-4">{achievement.id}</td>
                     <td className="border px-8 py-4">{achievement.description || "-"}</td>
                     <td className="border px-8 py-4">{achievement.isEnabled ? "✅" : "❌"}</td>

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -6,6 +6,7 @@ import { SyncLoader } from "react-spinners";
 import * as Yup from "yup";
 import { getAchievements } from "../api/achievements";
 import { getGameType, upsertGameType } from "../api/gamedev";
+import AddOrEditAchievementModal from "../ui/AddOrEditAchievementModal";
 
 import Button from "../ui/Button";
 import TextInput from "../ui/TextInput";
@@ -29,10 +30,13 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
   );
   const [achievements, setAchievements] = useState<IAchievement[]>([]);
   const [isUpdatingGameName, setIsUpdatingGameName] = useState<boolean>(false);
+  const [showModal, setShowModal] = useState<boolean>(false);
+
   const [errorMessage, setErrorMessage] = useState(null);
   const navigate = useNavigate();
 
   const { gameTypeId } = useParams<{ gameTypeId: string }>();
+  
 
   const onSubmit = async (values: IForm, _actions: FormikHelpers<IForm>) => {
     setIsLoading(true);
@@ -147,8 +151,12 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
     }
   }
 
+  const openAchievementModal = (achievement: IAchievement) => {
+    setShowModal(true)
+  }
+
   return (
-    <div>
+    <>
       <h2 className="text-2xl font-bold italic font-sans mb-8">
         {editMode ? "UPDATE GAME" : "NEW GAME"}
       </h2>
@@ -280,7 +288,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
                     <td className="border px-8 py-4">
                       <Button
                         onClick={() => {
-                          console.log("SHOW EDIT ACHIEVEMENT MODAL");
+                          openAchievementModal(achievement)
                         }}
                       >
                         Edit
@@ -292,7 +300,8 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
           </table>
         </div>
       </div>
-    </div>
+      <AddOrEditAchievementModal show={showModal} onClose={() => setShowModal(false)} />
+    </>
   );
 };
 

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -30,6 +30,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
   );
   const [achievements, setAchievements] = useState<IAchievement[]>([]);
   const [isUpdatingGameName, setIsUpdatingGameName] = useState<boolean>(false);
+  const [shouldLoadAchievements, setShouldLoadAchievements] = useState<boolean>(true);
   const [selectedAchievement, setSelectedAchievement] = useState<IAchievement>();
   const [selectedLeaderboard, setSelectedLeaderboard] = useState<ILeaderboard>();
   const [showModal, setShowModal] = useState<boolean>(false);
@@ -95,6 +96,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
         if (!gameTypeId) {
           return;
         }
+        console.log('WILL RELOAD!!!')
         const gameType = await getGameType(Number(gameTypeId));
         setValues({
           id: gameType.id,
@@ -121,11 +123,12 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
   useEffect(() => {
     async function fetchAchievementsData() {
       try {
-        if (!gameTypeId) {
+        if (!gameTypeId || !shouldLoadAchievements) {
           return;
         }
         const achievements = await getAchievements(Number(gameTypeId));
-        setAchievements(achievements)
+        setAchievements(achievements);
+        setShouldLoadAchievements(false);
         return achievements;
       } catch (error: any) {
         console.log({ error });
@@ -135,7 +138,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
     }
 
     fetchAchievementsData();
-  }, [gameTypeId]);
+  }, [gameTypeId, shouldLoadAchievements]);
 
   if (errorMessage) {
     return <div>{errorMessage}</div>;
@@ -153,9 +156,20 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
     }
   }
 
-  const openAchievementModal = (achievement: IAchievement) => {
+  const openAchievementModal = (achievement?: IAchievement) => {
     setSelectedAchievement(achievement);
     setShowModal(true);
+  }
+
+  const handleCloseAchievementModal = () => {
+    setSelectedAchievement(undefined);
+    setShowModal(false);
+  }
+
+  const handlePostSubmitAchievement = () => {
+    setSelectedAchievement(undefined);
+    setShowModal(false);
+    setShouldLoadAchievements(true)
   }
 
   return (
@@ -256,7 +270,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
             Achievements
           </h2>
           <div className="my-4">
-            <Button onClick={() => console.log("SHOW NEW ACHIEVEMENT MODAL")}>
+            <Button onClick={openAchievementModal}>
               New Achievement
             </Button>
             </div>
@@ -303,7 +317,8 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
           </table>
         </div>
       </div>
-      <AddOrEditAchievementModal show={showModal} onClose={() => setShowModal(false)} selectedAchievement={selectedAchievement}/>
+      <AddOrEditAchievementModal show={showModal} onClose={handlePostSubmitAchievement}  selectedAchievement={selectedAchievement}/>
+      {/* <AddOrEditAchievementModal show={showModal} onClose={handleCloseAchievementModal} onSubmit={handlePostSubmit} selectedAchievement={selectedAchievement}/> */}
     </>
   );
 };

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -7,6 +7,7 @@ import * as Yup from "yup";
 import { getAchievements } from "../api/achievements";
 import { getGameType, upsertGameType } from "../api/gamedev";
 import AddOrEditAchievementModal from "../ui/AddOrEditAchievementModal";
+import AddOrEditLeaderboardModal from "../ui/AddOrEditLeaderboardModal";
 
 import Button from "../ui/Button";
 import TextInput from "../ui/TextInput";
@@ -31,9 +32,11 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
   const [achievements, setAchievements] = useState<IAchievement[]>([]);
   const [isUpdatingGameName, setIsUpdatingGameName] = useState<boolean>(false);
   const [shouldLoadAchievements, setShouldLoadAchievements] = useState<boolean>(true);
+  const [shouldLoadGameType, setShouldGameType] = useState<boolean>(true);
   const [selectedAchievement, setSelectedAchievement] = useState<IAchievement>();
   const [selectedLeaderboard, setSelectedLeaderboard] = useState<ILeaderboard>();
   const [showModal, setShowModal] = useState<boolean>(false);
+  const [showLeaderboardModal, setShowLeaderboardModal] = useState<boolean>(false);
 
   const [errorMessage, setErrorMessage] = useState(null);
   const navigate = useNavigate();
@@ -93,10 +96,9 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
   useEffect(() => {
     async function fetchGameTypeData() {
       try {
-        if (!gameTypeId) {
+        if (!gameTypeId || !shouldLoadGameType) {
           return;
         }
-        console.log('WILL RELOAD!!!')
         const gameType = await getGameType(Number(gameTypeId));
         setValues({
           id: gameType.id,
@@ -109,6 +111,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
 
         setGameType(gameType);
         setIsLoading(false);
+        setShouldGameType(false);
         return gameType;
       } catch (error: any) {
         console.log({ error });
@@ -118,7 +121,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
     }
 
     fetchGameTypeData();
-  }, [gameTypeId, setValues]);
+  }, [gameTypeId, setValues, shouldLoadGameType]);
 
   useEffect(() => {
     async function fetchAchievementsData() {
@@ -161,15 +164,21 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
     setShowModal(true);
   }
 
-  const handleCloseAchievementModal = () => {
-    setSelectedAchievement(undefined);
-    setShowModal(false);
+  const openLeaderboardModal = (leaderboard?: ILeaderboard) => {
+    setSelectedLeaderboard(leaderboard);
+    setShowLeaderboardModal(true);
   }
 
   const handlePostSubmitAchievement = () => {
     setSelectedAchievement(undefined);
     setShowModal(false);
     setShouldLoadAchievements(true)
+  }
+
+  const handlePostSubmitLeaderboard = () => {
+    setSelectedLeaderboard(undefined);
+    setShowLeaderboardModal(false);
+    setShouldGameType(true)
   }
 
   return (
@@ -223,7 +232,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
             Leaderboards
           </h2>
           <div className="my-4">
-            <Button onClick={() => console.log("NEW LEADERBOARD MODAL")}>
+            <Button onClick={openLeaderboardModal}>
               New Leaderboard
             </Button>
           </div>
@@ -253,7 +262,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
                   <td className="border px-8 py-4">
                     <Button
                       onClick={() => {
-                        console.log("SHOW EDIT LEADERBOARD MODAL");
+                        openLeaderboardModal(leaderboard)
                       }}
                     >
                       Edit
@@ -318,7 +327,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
         </div>
       </div>
       <AddOrEditAchievementModal show={showModal} onClose={handlePostSubmitAchievement}  selectedAchievement={selectedAchievement}/>
-      {/* <AddOrEditAchievementModal show={showModal} onClose={handleCloseAchievementModal} onSubmit={handlePostSubmit} selectedAchievement={selectedAchievement}/> */}
+      <AddOrEditLeaderboardModal show={showLeaderboardModal} onClose={handlePostSubmitLeaderboard}  selectedLeaderboard={selectedLeaderboard}/>
     </>
   );
 };

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -31,7 +31,6 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
   const [isUpdatingGameName, setIsUpdatingGameName] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState(null);
   const navigate = useNavigate();
-  // let history = useHistory();
 
   const { gameTypeId } = useParams<{ gameTypeId: string }>();
 
@@ -157,7 +156,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
         <form className="py-10 mr-8">
           <div className="flex">
             <div>
-              {isUpdatingGameName ? 
+              {isUpdatingGameName || !editMode ? 
               ( 
                 <TextInput
                   label="Game Name"
@@ -173,16 +172,17 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
             }
             </div>
           </div>
-          <div className="flex  mt-4">
+
+          <div className={`flex  mt-4 ${!editMode && 'hidden'}`}>
             <section className="flex flex-col">
               <strong>Client Secret</strong>
-              <span>{currentGameType?.clientSecret}</span>
+              <span className="text-xs">{currentGameType?.clientSecret}</span>
             </section>
           </div>
-          <div className="flex mt-4">
+          <div className={`flex  mt-4 ${!editMode && 'hidden'}`}>
             <section className="flex flex-col">
               <strong>Signing Secret</strong>
-              <span>{currentGameType?.signingSecret}</span>
+              <span className="text-xs">{currentGameType?.signingSecret}</span>
             </section>
           </div>
 
@@ -193,16 +193,14 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
           </div>
         </form>
 
-        <div className="col-span-7 py-10">
+        <div className={`col-span-7 py-10 ${!editMode && 'hidden'}`}>
           <h2 className="text-2xl font-bold italic font-sans mb-8">
             Leaderboards
           </h2>
           <div className="my-4">
-            <Link to="/games/leaderboards/new">
-              <Button>
-                New Achievement
-              </Button>
-            </Link>
+            <Button onClick={() => console.log("NEW LEADERBOARD MODAL")}>
+              New Leaderboard
+            </Button>
           </div>
           <table className="shadow-lg bg-white border-collapse w-full">
             <tr>
@@ -230,7 +228,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
                   <td className="border px-8 py-4">
                     <Button
                       onClick={() => {
-                        console.log("Handle New Leaderboard Click");
+                        console.log("SHOW EDIT LEADERBOARD MODAL");
                       }}
                     >
                       Edit
@@ -242,16 +240,14 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
           </table>
         </div>
       
-        <div className="py-10 w-full">
+        <div className={`py-10 w-full ${!editMode && 'hidden'}`}>
           <h2 className="text-2xl font-bold italic font-sans mb-8">
             Achievements
           </h2>
           <div className="my-4">
-            <Link to="/games/achievements/new">
-              <Button>
-                New Achievement
-              </Button>
-            </Link>
+            <Button onClick={() => console.log("SHOW NEW ACHIEVEMENT MODAL")}>
+              New Achievement
+            </Button>
             </div>
           <table className="shadow-lg bg-white border-collapse max-w-xs">
             <tr>
@@ -284,7 +280,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
                     <td className="border px-8 py-4">
                       <Button
                         onClick={() => {
-                          console.log("Handle edit");
+                          console.log("SHOW EDIT ACHIEVEMENT MODAL");
                         }}
                       >
                         Edit

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { SyncLoader } from "react-spinners";
 import * as Yup from "yup";
-import { getAchievements } from "../api/acheivements";
+import { getAchievements } from "../api/achievements";
 import { getGameType, upsertGameType } from "../api/gamedev";
 
 import Button from "../ui/Button";
@@ -74,8 +74,8 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
     getFieldProps,
     getFieldMeta,
     handleSubmit,
-    dirty,
-    isValid,
+    // dirty,
+    // isValid,
     setValues,
   } = useFormik({
     initialValues: initialForm,
@@ -139,7 +139,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
     return <SyncLoader />;
   }
 
-  const isSubmitDisabled = !dirty || !isValid;
+  // const isSubmitDisabled = !dirty || !isValid;
 
   return (
     <div>

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -74,8 +74,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
     getFieldProps,
     getFieldMeta,
     handleSubmit,
-    // dirty,
-    // isValid,
+    isValid,
     setValues,
   } = useFormik({
     initialValues: initialForm,
@@ -139,7 +138,13 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
     return <SyncLoader />;
   }
 
-  // const isSubmitDisabled = !dirty || !isValid;
+  const handleEditButtonClick = () => {
+    if(isUpdatingGameName && isValid) {
+      handleSubmit()
+    } else {
+      setIsUpdatingGameName(true)
+    }
+  }
 
   return (
     <div>
@@ -147,7 +152,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
         {editMode ? "UPDATE GAME" : "NEW GAME"}
       </h2>
       <div className="flex flex-wrap">
-        <form onSubmit={handleSubmit} className="py-10 mr-8">
+        <form className="py-10 mr-8">
           <div className="flex">
             <div>
               {isUpdatingGameName ? 
@@ -180,8 +185,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
           </div>
 
           <div className="mt-4">
-            {/* FIX THIS LOGIC */}
-            <Button onClick={() => setIsUpdatingGameName(true)}>
+            <Button type="button" onClick={handleEditButtonClick}>
               {editMode ? "Update Game" : "Create Game"}
             </Button>
           </div>

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -1,6 +1,6 @@
 import { FormikHelpers, useFormik } from "formik";
 import { useEffect, useState } from "react";
-import { useParams, useNavigate, Router } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { SyncLoader } from "react-spinners";
 import * as Yup from "yup";
 import { getAchievements } from "../api/acheivements";
@@ -180,7 +180,8 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
           </div>
 
           <div className="mt-4">
-            <Button disabled={isSubmitDisabled} type="submit">
+            {/* FIX THIS LOGIC */}
+            <Button onClick={() => setIsUpdatingGameName(true)}>
               {editMode ? "Update Game" : "Create Game"}
             </Button>
           </div>
@@ -193,7 +194,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
           <div className="my-4">
             <Button
               onClick={() => {
-
+                console.log('NEW LEADERBOARD PAGE')
               }}
             >
               New Leaderboard

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -30,6 +30,8 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
   );
   const [achievements, setAchievements] = useState<IAchievement[]>([]);
   const [isUpdatingGameName, setIsUpdatingGameName] = useState<boolean>(false);
+  const [selectedAchievement, setSelectedAchievement] = useState<IAchievement>();
+  const [selectedLeaderboard, setSelectedLeaderboard] = useState<ILeaderboard>();
   const [showModal, setShowModal] = useState<boolean>(false);
 
   const [errorMessage, setErrorMessage] = useState(null);
@@ -145,14 +147,15 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
 
   const handleEditButtonClick = () => {
     if(isUpdatingGameName && isValid) {
-      handleSubmit()
+      handleSubmit();
     } else {
-      setIsUpdatingGameName(true)
+      setIsUpdatingGameName(true);
     }
   }
 
   const openAchievementModal = (achievement: IAchievement) => {
-    setShowModal(true)
+    setSelectedAchievement(achievement);
+    setShowModal(true);
   }
 
   return (
@@ -300,7 +303,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
           </table>
         </div>
       </div>
-      <AddOrEditAchievementModal show={showModal} onClose={() => setShowModal(false)} />
+      <AddOrEditAchievementModal show={showModal} onClose={() => setShowModal(false)} selectedAchievement={selectedAchievement}/>
     </>
   );
 };

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -1,5 +1,6 @@
 import { FormikHelpers, useFormik } from "formik";
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { useParams, useNavigate } from "react-router-dom";
 import { SyncLoader } from "react-spinners";
 import * as Yup from "yup";
@@ -30,6 +31,7 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
   const [isUpdatingGameName, setIsUpdatingGameName] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState(null);
   const navigate = useNavigate();
+  // let history = useHistory();
 
   const { gameTypeId } = useParams<{ gameTypeId: string }>();
 
@@ -196,13 +198,11 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
             Leaderboards
           </h2>
           <div className="my-4">
-            <Button
-              onClick={() => {
-                console.log('NEW LEADERBOARD PAGE')
-              }}
-            >
-              New Leaderboard
-            </Button>
+            <Link to="/games/leaderboards/new">
+              <Button>
+                New Achievement
+              </Button>
+            </Link>
           </div>
           <table className="shadow-lg bg-white border-collapse w-full">
             <tr>
@@ -219,13 +219,13 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
             {currentGameType?._leaderboards?.map(
               (leaderboard: ILeaderboard) => (
                 <tr>
-                  <td className="border px-8 py-4">{leaderboard.id}</td>
-                  <td className="border px-8 py-4">{leaderboard.name}</td>
+                  <td className="border px-8 py-4" ><Link to={`/games/leaderboards/${leaderboard.id}`}>{leaderboard.id}</Link></td>
+                  <td className="border px-8 py-4"><Link to={`/games/leaderboards/${leaderboard.id}`}>{leaderboard.name}</Link></td>
                   <td className="border px-8 py-4">
-                    {leaderboard.scoreStrategy}
+                    <Link to={`/games/leaderboards/${leaderboard.id}`}>{leaderboard.scoreStrategy}</Link>
                   </td>
                   <td className="border px-8 py-4">
-                    {leaderboard.resetStrategy}
+                    <Link to={`/games/leaderboards/${leaderboard.id}`}>{leaderboard.resetStrategy}</Link>
                   </td>
                   <td className="border px-8 py-4">
                     <Button
@@ -247,13 +247,11 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
             Achievements
           </h2>
           <div className="my-4">
-              <Button
-                onClick={() => {
-                  console.log("Handle New Achievement Click");
-                }}
-              >
+            <Link to="/games/achievements/new">
+              <Button>
                 New Achievement
               </Button>
+            </Link>
             </div>
           <table className="shadow-lg bg-white border-collapse max-w-xs">
             <tr>

--- a/src/pages/LeaderboardsPage.tsx
+++ b/src/pages/LeaderboardsPage.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { getLeaderboard } from "../api/leaderboards";
+
+const LeaderboardsPage =() => {
+    const leaderboard = useState<ILeaderboard | undefined>();
+    useEffect(() => {
+        async function fetchLeaderboard() {
+            const leaderboard = await getLeaderboard(1,2); // TODO GET FROM PARAM
+        }
+
+        fetchLeaderboard();
+    }, []);
+
+    return (
+        <div>
+            <h2 className="text-2xl font-bold italic font-sans mb-8">
+                ACHIEVEMENTS
+            </h2>
+
+            {leaderboard ? (
+                <>
+                    <table>
+                        <tr></tr>
+                    </table>
+                </>
+            ) : (
+                <p>Loading</p>
+            )}
+        </div>
+    );
+};
+
+export default LeaderboardsPage;

--- a/src/pages/LeaderboardsPage.tsx
+++ b/src/pages/LeaderboardsPage.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from "react";
-import { getLeaderboard } from "../api/leaderboards";
+import { getGameTypeLeaderboards } from "../api/leaderboards";
+import Button from "../ui/Button";
 
 const LeaderboardsPage =() => {
-    const leaderboard = useState<ILeaderboard | undefined>();
+    const [leaderboards, setLeaderboards] = useState<ILeaderboard[] | undefined>();
     useEffect(() => {
         async function fetchLeaderboard() {
-            const leaderboard = await getLeaderboard(1,2); // TODO GET FROM PARAM
+            const leaderboardsRes =  await getGameTypeLeaderboards(4); // TODO GET FROM PARAM
+            setLeaderboards(leaderboardsRes);
+            return leaderboardsRes;
         }
 
         fetchLeaderboard();
@@ -14,18 +17,44 @@ const LeaderboardsPage =() => {
     return (
         <div>
             <h2 className="text-2xl font-bold italic font-sans mb-8">
-                ACHIEVEMENTS
+                LEADERBOARDS
             </h2>
 
-            {leaderboard ? (
-                <>
-                    <table>
-                        <tr></tr>
-                    </table>
-                </>
-            ) : (
-                <p>Loading</p>
-            )}
+                <table className="shadow-lg bg-white border-collapse w-full">
+                    <tr>
+                    <th className="bg-gray-100 border text-left px-8 py-4">id</th>
+                    <th className="bg-gray-100 border text-left px-8 py-4">name</th>
+                    <th className="bg-gray-100 border text-left px-8 py-4">
+                        scoreStrategy
+                    </th>
+                    <th className="bg-gray-100 border text-left px-8 py-4">
+                        resetStrategy
+                    </th>
+                    <th className="bg-gray-100 border text-left px-8 py-4">Edit</th>
+                    </tr>
+                    {leaderboards && leaderboards?.map(
+                    (leaderboard: ILeaderboard) => (
+                        <tr>
+                        <td className="border px-8 py-4" >{leaderboard.id}</td>
+                        <td className="border px-8 py-4">{leaderboard.name}</td>
+                        <td className="border px-8 py-4">
+                            {leaderboard.scoreStrategy}
+                        </td>
+                        <td className="border px-8 py-4">
+                            {leaderboard.resetStrategy}
+                        </td>
+                        <td className="border px-8 py-4">
+                            <Button
+                                onClick={() => {
+                                    console.log("SHOW EDIT LEADERBOARD MODAL");
+                                }}
+                            >
+                                Edit
+                            </Button>
+                        </td>
+                        </tr>
+                    ))}
+                </table>
         </div>
     );
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -23,6 +23,7 @@ interface IGameType {
 
 interface ILeaderboard {
   id?: number;
+  _gameTypeId: number;
   name: string;
   scoreStrategy: string;
   resetStrategy: string;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -22,20 +22,20 @@ interface IGameType {
 }
 
 interface ILeaderboard {
-  id: number;
+  id?: number;
   name: string;
   scoreStrategy: string;
   resetStrategy: string;
 }
 
-interface IAchievement extends SignInOut {
-  id: number;
+interface IAchievement {
+  id?: number;
   _gameTypeId: number;
   description: string;
-  gameType: IGameType;
+  gameType?: IGameType;
   isEnabled: boolean;
   targetValue: number;
-  createdAt: string;
+  createdAt?: string;
   updatedAt: string;
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -28,6 +28,16 @@ interface ILeaderboard {
   resetStrategy: string;
 }
 
+interface IAchievement extends SignInOut {
+  id: number;
+  _gameTypeId: number;
+  description: string;
+  gameType: IGameType;
+  isEnabled: boolean;
+  targetValue: number;
+  createdAt: string;
+  updatedAt: string;
+}
 
 interface ITeam {
   id?: number;

--- a/src/ui/AddOrEditAchievementModal/AddOrEditAchievementModal.tsx
+++ b/src/ui/AddOrEditAchievementModal/AddOrEditAchievementModal.tsx
@@ -1,0 +1,85 @@
+import { useFormik } from "formik";
+import { useEffect, useState } from "react";
+import Button from "../Button";
+import Checkbox from "../Checkbox";
+import Modal from "../Modal";
+import TextInput from "../TextInput";
+
+interface IProps {
+    show: boolean;
+    onClose: () => void;
+}
+
+const AddOrEditAchievementModal = ({
+    show,
+    onClose,
+}: IProps) => {
+
+    // useEffect
+    // const {
+    //     getFieldProps,
+    //     getFieldMeta,
+    //     handleSubmit,
+    //     isValid,
+    //     setValues,
+    //   } = useFormik({
+    //     // initialValues: {},
+    //     // onSubmit,
+    //     // validationSchema,
+    //   });
+
+    return (
+        <section>
+            <Modal show={show} onClose={onClose}>
+                <h2 className="text-xteamaccent font-extrabold italic text-xl">
+                    Edit Achievement
+                </h2>
+                <form>
+                    <div className="flex space-x-6">
+                    <div>
+                        <TextInput
+                        label="Description"
+                        name="Description"
+                        // {...getFieldProps("description")}
+                        // {...getFieldMeta("description")}
+                        />
+                    </div>
+
+                    <div>
+                        <TextInput
+                        label="Target Value"
+                        name="target"
+                        // {...getFieldProps("targetValue")}
+                        // {...getFieldMeta("targetValue")}
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                        className="block text-gray-700 text-sm font-bold mt-9"
+                        htmlFor="isEnabled"
+                        >
+                        <Checkbox 
+                            // {...getFieldProps("isEnabled")}
+                            name="target"
+                            onChange={() => console.log("TEST")}
+                            value={"1"}
+                            // label="Is Enabled"
+                        >
+                            isEnabled
+                        </Checkbox>
+                        </label>
+                    </div>
+                    </div>
+                    <div className="mt-4 flex justify-center">
+                        <Button type="submit">
+                            Save
+                        </Button>
+                    </div>
+                </form>
+            </Modal>
+        </section>
+    );
+};
+
+export default AddOrEditAchievementModal;

--- a/src/ui/AddOrEditAchievementModal/AddOrEditAchievementModal.tsx
+++ b/src/ui/AddOrEditAchievementModal/AddOrEditAchievementModal.tsx
@@ -80,40 +80,40 @@ const AddOrEditAchievementModal = ({
                     Edit Achievement
                 </h2>
                 <form onSubmit={handleSubmit}>
-                    <div className="flex space-x-6">
-                    <div>
-                        <TextInput
-                        label="Description"
-                        {...getFieldProps("description")}
-                        {...getFieldMeta("description")}
-                        />
-                    </div>
+                    <div className="flex space-x-6 pb-8">
+                        <div>
+                            <TextInput
+                            label="Description"
+                            {...getFieldProps("description")}
+                            {...getFieldMeta("description")}
+                            />
+                        </div>
 
-                    <div>
-                        <TextInput
-                        label="Target Value"
-                        {...getFieldProps("targetValue")}
-                        {...getFieldMeta("targetValue")}
-                        />
-                    </div>
+                        <div>
+                            <TextInput
+                            label="Target Value"
+                            {...getFieldProps("targetValue")}
+                            {...getFieldMeta("targetValue")}
+                            />
+                        </div>
 
-                    <div>
-                        <label
-                        className="block text-gray-700 text-sm font-bold mt-9"
-                        htmlFor="isEnabled"
-                        >
-                        <Checkbox 
-                            {...getFieldProps("isEnabled")}
-                        >
-                            isEnabled
-                        </Checkbox>
-                        </label>
-                    </div>
-                    </div>
-                    <div className="mt-8 flex justify-center">
-                        <Button type="submit" disabled={!isValid}>
-                            Save
-                        </Button>
+                        <div>
+                            <label
+                            className="block text-gray-700 text-sm font-bold mt-9"
+                            htmlFor="isEnabled"
+                            >
+                            <Checkbox 
+                                {...getFieldProps("isEnabled")}
+                            >
+                                isEnabled
+                            </Checkbox>
+                            </label>
+                        </div>
+                        <div className="mt-8 flex justify-center flex-1">
+                            <Button type="submit" disabled={!isValid}>
+                                Save
+                            </Button>
+                        </div>
                     </div>
                 </form>
             </Modal>

--- a/src/ui/AddOrEditAchievementModal/AddOrEditAchievementModal.tsx
+++ b/src/ui/AddOrEditAchievementModal/AddOrEditAchievementModal.tsx
@@ -1,5 +1,5 @@
 import { useFormik } from "formik";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import * as Yup from "yup";
 import { useParams } from "react-router-dom";
 
@@ -30,8 +30,6 @@ const AddOrEditAchievementModal = ({
     const { gameTypeId } = useParams<{ gameTypeId: string }>();
 
     const onSubmit = async (values: IAchievementForm) => {
-        console.log("SUBMIT!",values);
-        console.log("OBJECT!",selectedAchievement);
         await upsertAchievement({
             ...(selectedAchievement?.id && { id: selectedAchievement?.id }),
             _gameTypeId: selectedAchievement?._gameTypeId || parseInt(gameTypeId || ""),
@@ -78,7 +76,7 @@ const AddOrEditAchievementModal = ({
     return (
         <section>
             <Modal show={show} onClose={onClose}>
-                <h2 className="text-xteamaccent font-extrabold italic text-xl">
+                <h2 className="text-xteamaccent font-extrabold italic text-xl mb-8">
                     Edit Achievement
                 </h2>
                 <form onSubmit={handleSubmit}>
@@ -112,7 +110,7 @@ const AddOrEditAchievementModal = ({
                         </label>
                     </div>
                     </div>
-                    <div className="mt-4 flex justify-center">
+                    <div className="mt-8 flex justify-center">
                         <Button type="submit" disabled={!isValid}>
                             Save
                         </Button>

--- a/src/ui/AddOrEditAchievementModal/index.tsx
+++ b/src/ui/AddOrEditAchievementModal/index.tsx
@@ -1,0 +1,3 @@
+import AddOrEditAchievementModal from "./AddOrEditAchievementModal";
+
+export default AddOrEditAchievementModal;

--- a/src/ui/AddOrEditLeaderboardModal/AddOrEditLeaderboardModal.tsx
+++ b/src/ui/AddOrEditLeaderboardModal/AddOrEditLeaderboardModal.tsx
@@ -5,9 +5,9 @@ import { useParams } from "react-router-dom";
 
 import { upsertLeaderboard } from "../../api/leaderboards";
 import Button from "../Button";
-import Checkbox from "../Checkbox";
 import Modal from "../Modal";
 import TextInput from "../TextInput";
+import Dropdown from "../Dropdown";
 
 interface IProps {
     show: boolean;
@@ -48,7 +48,7 @@ const AddOrEditLeaderboardModal = ({
 
     const initialForm: ILeaderboardForm = {
         name: "",
-        scoreStrategy: "reset",
+        scoreStrategy: "highest",
         resetStrategy: "weekly",
       };
 
@@ -79,7 +79,7 @@ const AddOrEditLeaderboardModal = ({
                     Edit Leaderboard
                 </h2>
                 <form onSubmit={handleSubmit}>
-                    <div className="flex space-x-6">
+                    <div className="flex space-x-6 pb-8">
                         <div>
                             <TextInput
                             label="Name"
@@ -89,25 +89,27 @@ const AddOrEditLeaderboardModal = ({
                         </div>
 
                         <div>
-                            <TextInput
-                            label="Score Strategy"
-                            {...getFieldProps("scoreStrategy")}
-                            {...getFieldMeta("scoreStrategy")}
-                            />
+                            <Dropdown fieldProps={getFieldProps("scoreStrategy")} label="Score Strategy">
+                                <option value="highest" label="Highest" />
+                                <option value="lowest" label="Lowest" />
+                                <option value="sum" label="Sum" />
+                                <option value="latest" label="Latest" />
+                            </Dropdown>
                         </div>
 
                         <div>
-                            <TextInput
-                            label="Reset Strategy"
-                            {...getFieldProps("resetStrategy")}
-                            {...getFieldMeta("resetStrategy")}
-                            />
+                            <Dropdown fieldProps={getFieldProps("resetStrategy")} label="Reset Strategy">
+                                <option value="daily" label="Daily" />
+                                <option value="weekly" label="Weekly" />
+                                <option value="monthly" label="Monthly" />
+                                <option value="never" label="Never" />
+                            </Dropdown>
                         </div>
-                    </div>
-                    <div className="mt-8 flex justify-center">
-                        <Button type="submit" disabled={!isValid}>
-                            Save
-                        </Button>
+                        <div className="mt-8 flex justify-center flex-1">
+                            <Button type="submit" disabled={!isValid} >
+                                Save
+                            </Button>
+                        </div>
                     </div>
                 </form>
             </Modal>

--- a/src/ui/AddOrEditLeaderboardModal/AddOrEditLeaderboardModal.tsx
+++ b/src/ui/AddOrEditLeaderboardModal/AddOrEditLeaderboardModal.tsx
@@ -8,113 +8,123 @@ import Button from "../Button";
 import Modal from "../Modal";
 import TextInput from "../TextInput";
 import Dropdown from "../Dropdown";
+import {
+  resetStrategies,
+  scoreStrategies,
+} from "../../utils/leaderboardStrategies";
 
 interface IProps {
-    show: boolean;
-    onClose: () => void;
-    selectedLeaderboard?: ILeaderboard;
+  show: boolean;
+  onClose: () => void;
+  selectedLeaderboard?: ILeaderboard;
 }
 
 interface ILeaderboardForm {
-    id?: number;
-    name: string;
-    scoreStrategy: string;
-    resetStrategy: string;
+  id?: number;
+  name: string;
+  scoreStrategy: string;
+  resetStrategy: string;
 }
 
 const AddOrEditLeaderboardModal = ({
-    show,
-    onClose,
-    selectedLeaderboard,
+  show,
+  onClose,
+  selectedLeaderboard,
 }: IProps) => {
-    const { gameTypeId } = useParams<{ gameTypeId: string }>();
+  const { gameTypeId } = useParams<{ gameTypeId: string }>();
 
-    const onSubmit = async (values: ILeaderboardForm) => {
-        await upsertLeaderboard({
-            ...(selectedLeaderboard?.id && { id: selectedLeaderboard?.id }),
-            _gameTypeId: selectedLeaderboard?._gameTypeId || parseInt(gameTypeId || ""),
-            name: values.name,
-            scoreStrategy: values.scoreStrategy,
-            resetStrategy: values.resetStrategy,
-          });
-        onClose();
-    }
+  const onSubmit = async (values: ILeaderboardForm) => {
+    await upsertLeaderboard({
+      ...(selectedLeaderboard?.id && { id: selectedLeaderboard?.id }),
+      _gameTypeId:
+        selectedLeaderboard?._gameTypeId || parseInt(gameTypeId || ""),
+      name: values.name,
+      scoreStrategy: values.scoreStrategy,
+      resetStrategy: values.resetStrategy,
+    });
+    onClose();
+  };
 
-    const validationSchema = Yup.object({
-        name: Yup.string().required().label("Desctiption"),
-        scoreStrategy: Yup.string().required().label("Score Strategy"),
-        resetStrategy: Yup.string().required().label("Reset Strategy"),
-      });
+  const validationSchema = Yup.object({
+    name: Yup.string().required().label("Desctiption"),
+    scoreStrategy: Yup.string().required().label("Score Strategy"),
+    resetStrategy: Yup.string().required().label("Reset Strategy"),
+  });
 
-    const initialForm: ILeaderboardForm = {
-        name: "",
-        scoreStrategy: "highest",
-        resetStrategy: "weekly",
-      };
+  const initialForm: ILeaderboardForm = {
+    name: "",
+    scoreStrategy: "highest",
+    resetStrategy: "weekly",
+  };
 
-    const {
-        getFieldProps,
-        getFieldMeta,
-        handleSubmit,
-        isValid,
-        setValues,
-      } = useFormik({
-        initialValues: initialForm,
-        onSubmit,
-        validationSchema,
-      });
+  const { getFieldProps, getFieldMeta, handleSubmit, isValid, setValues } =
+    useFormik({
+      initialValues: initialForm,
+      onSubmit,
+      validationSchema,
+    });
 
-    useEffect(() => {
-        setValues({
-            name: selectedLeaderboard?.name || "",
-            scoreStrategy: selectedLeaderboard?.scoreStrategy || "",
-            resetStrategy: selectedLeaderboard?.scoreStrategy || "",
-        });
-    }, [selectedLeaderboard, setValues])
+  useEffect(() => {
+    setValues({
+      name: selectedLeaderboard?.name || "",
+      scoreStrategy: selectedLeaderboard?.scoreStrategy || "",
+      resetStrategy: selectedLeaderboard?.scoreStrategy || "",
+    });
+  }, [selectedLeaderboard, setValues]);
 
-    return (
-        <section>
-            <Modal show={show} onClose={onClose}>
-                <h2 className="text-xteamaccent font-extrabold italic text-xl mb-8">
-                    Edit Leaderboard
-                </h2>
-                <form onSubmit={handleSubmit}>
-                    <div className="flex space-x-6 pb-8">
-                        <div>
-                            <TextInput
-                            label="Name"
-                            {...getFieldProps("name")}
-                            {...getFieldMeta("name")}
-                            />
-                        </div>
+  return (
+    <section>
+      <Modal show={show} onClose={onClose}>
+        <h2 className="text-xteamaccent font-extrabold italic text-xl mb-8">
+          Edit Leaderboard
+        </h2>
+        <form onSubmit={handleSubmit}>
+          <div className="flex space-x-6 pb-8">
+            <div>
+              <TextInput
+                label="Name"
+                {...getFieldProps("name")}
+                {...getFieldMeta("name")}
+              />
+            </div>
 
-                        <div>
-                            <Dropdown fieldProps={getFieldProps("scoreStrategy")} label="Score Strategy">
-                                <option value="highest" label="Highest" />
-                                <option value="lowest" label="Lowest" />
-                                <option value="sum" label="Sum" />
-                                <option value="latest" label="Latest" />
-                            </Dropdown>
-                        </div>
+            <div>
+              <Dropdown
+                fieldProps={getFieldProps("scoreStrategy")}
+                label="Score Strategy"
+              >
+                {scoreStrategies.map((scoreStrategy) => (
+                  <option
+                    value={scoreStrategy.toLowerCase()}
+                    label={scoreStrategy}
+                  />
+                ))}
+              </Dropdown>
+            </div>
 
-                        <div>
-                            <Dropdown fieldProps={getFieldProps("resetStrategy")} label="Reset Strategy">
-                                <option value="daily" label="Daily" />
-                                <option value="weekly" label="Weekly" />
-                                <option value="monthly" label="Monthly" />
-                                <option value="never" label="Never" />
-                            </Dropdown>
-                        </div>
-                        <div className="mt-8 flex justify-center flex-1">
-                            <Button type="submit" disabled={!isValid} >
-                                Save
-                            </Button>
-                        </div>
-                    </div>
-                </form>
-            </Modal>
-        </section>
-    );
+            <div>
+              <Dropdown
+                fieldProps={getFieldProps("resetStrategy")}
+                label="Reset Strategy"
+              >
+                {resetStrategies.map((resetStrategy) => (
+                  <option
+                    value={resetStrategy.toLowerCase()}
+                    label={resetStrategy}
+                  />
+                ))}
+              </Dropdown>
+            </div>
+            <div className="mt-8 flex justify-center flex-1">
+              <Button type="submit" disabled={!isValid}>
+                Save
+              </Button>
+            </div>
+          </div>
+        </form>
+      </Modal>
+    </section>
+  );
 };
 
 export default AddOrEditLeaderboardModal;

--- a/src/ui/AddOrEditLeaderboardModal/AddOrEditLeaderboardModal.tsx
+++ b/src/ui/AddOrEditLeaderboardModal/AddOrEditLeaderboardModal.tsx
@@ -1,0 +1,118 @@
+import { useFormik } from "formik";
+import { useEffect } from "react";
+import * as Yup from "yup";
+import { useParams } from "react-router-dom";
+
+import { upsertLeaderboard } from "../../api/leaderboards";
+import Button from "../Button";
+import Checkbox from "../Checkbox";
+import Modal from "../Modal";
+import TextInput from "../TextInput";
+
+interface IProps {
+    show: boolean;
+    onClose: () => void;
+    selectedLeaderboard?: ILeaderboard;
+}
+
+interface ILeaderboardForm {
+    id?: number;
+    name: string;
+    scoreStrategy: string;
+    resetStrategy: string;
+}
+
+const AddOrEditLeaderboardModal = ({
+    show,
+    onClose,
+    selectedLeaderboard,
+}: IProps) => {
+    const { gameTypeId } = useParams<{ gameTypeId: string }>();
+
+    const onSubmit = async (values: ILeaderboardForm) => {
+        await upsertLeaderboard({
+            ...(selectedLeaderboard?.id && { id: selectedLeaderboard?.id }),
+            _gameTypeId: selectedLeaderboard?._gameTypeId || parseInt(gameTypeId || ""),
+            name: values.name,
+            scoreStrategy: values.scoreStrategy,
+            resetStrategy: values.resetStrategy,
+          });
+        onClose();
+    }
+
+    const validationSchema = Yup.object({
+        name: Yup.string().required().label("Desctiption"),
+        scoreStrategy: Yup.string().required().label("Score Strategy"),
+        resetStrategy: Yup.string().required().label("Reset Strategy"),
+      });
+
+    const initialForm: ILeaderboardForm = {
+        name: "",
+        scoreStrategy: "reset",
+        resetStrategy: "weekly",
+      };
+
+    const {
+        getFieldProps,
+        getFieldMeta,
+        handleSubmit,
+        isValid,
+        setValues,
+      } = useFormik({
+        initialValues: initialForm,
+        onSubmit,
+        validationSchema,
+      });
+
+    useEffect(() => {
+        setValues({
+            name: selectedLeaderboard?.name || "",
+            scoreStrategy: selectedLeaderboard?.scoreStrategy || "",
+            resetStrategy: selectedLeaderboard?.scoreStrategy || "",
+        });
+    }, [selectedLeaderboard, setValues])
+
+    return (
+        <section>
+            <Modal show={show} onClose={onClose}>
+                <h2 className="text-xteamaccent font-extrabold italic text-xl mb-8">
+                    Edit Leaderboard
+                </h2>
+                <form onSubmit={handleSubmit}>
+                    <div className="flex space-x-6">
+                        <div>
+                            <TextInput
+                            label="Name"
+                            {...getFieldProps("name")}
+                            {...getFieldMeta("name")}
+                            />
+                        </div>
+
+                        <div>
+                            <TextInput
+                            label="Score Strategy"
+                            {...getFieldProps("scoreStrategy")}
+                            {...getFieldMeta("scoreStrategy")}
+                            />
+                        </div>
+
+                        <div>
+                            <TextInput
+                            label="Reset Strategy"
+                            {...getFieldProps("resetStrategy")}
+                            {...getFieldMeta("resetStrategy")}
+                            />
+                        </div>
+                    </div>
+                    <div className="mt-8 flex justify-center">
+                        <Button type="submit" disabled={!isValid}>
+                            Save
+                        </Button>
+                    </div>
+                </form>
+            </Modal>
+        </section>
+    );
+};
+
+export default AddOrEditLeaderboardModal;

--- a/src/ui/AddOrEditLeaderboardModal/index.tsx
+++ b/src/ui/AddOrEditLeaderboardModal/index.tsx
@@ -1,0 +1,3 @@
+import AddOrEditLeaderboardModal from "./AddOrEditLeaderboardModal";
+
+export default AddOrEditLeaderboardModal;

--- a/src/utils/leaderboardStrategies.ts
+++ b/src/utils/leaderboardStrategies.ts
@@ -1,0 +1,4 @@
+
+export const scoreStrategies = ["Highest", "Lowest", "Sum", "Latest"];
+
+export const resetStrategies = ["Daily", "Weekly", "Monthly", "Never" ];


### PR DESCRIPTION
This PR adds two modals on Edit Game Page, for inserting/updating both Achievements and Leaderboards.

Also fixes the layout of the page when inserting a new Game, which was weird. 

This is how it's
<img width="1433" alt="Captura de Tela 2022-06-24 às 18 25 10" src="https://user-images.githubusercontent.com/790844/175695949-0a8cf0b6-3228-4dcc-910b-3b1a97fc84af.png">
<img width="1430" alt="Captura de Tela 2022-06-24 às 18 25 21" src="https://user-images.githubusercontent.com/790844/175695955-ee19b799-5885-498a-a28d-c2db71df1615.png">
 looking like:
