### PR TITLE
[XTG-291] Floors Page - Design Improvements

### DIFF
--- a/src/helpers/emojiHelper.tsx
+++ b/src/helpers/emojiHelper.tsx
@@ -64,13 +64,17 @@ export const emojiToImageSrc = (emoji: string, allEmoji: IAllEmoji) => {
 export const emojiToImageTag = (
     emoji: string,
     allEmoji: IAllEmoji,
-    className?: string
+    className?: string,
+    qty?: number,
 ) => {
     return (
-        <img
-            className={`inline ${className || `h-6 w-6`}`}
-            src={emojiToImageSrc(emoji, allEmoji)}
-            alt={emoji + " emoji"}
-        />
+        <div className="flex flex-col text-center w-14">
+            <img
+                className={`${className || `h-6 w-6`}`}
+                src={emojiToImageSrc(emoji, allEmoji)}
+                alt={emoji + " emoji"}
+            />
+            {qty && <span className="text-sm">x{qty}</span>}
+        </div>
     );
 };

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -223,7 +223,6 @@ const GameEditorPage = function GameEditorPage({ editMode }: IProps) {
           <div className={`flex  mt-4 ${!editMode && 'hidden'}`}>
             <section className="flex flex-col">
               <strong>Client Secret</strong>
-              {/* <span className="text-xs">{currentGameType?.clientSecret}</span> */}
               <div className="flex gap-1">
                 <span className="text-xs">{currentGameType?.clientSecret} </span>
                 <span className={`cursor-pointer w-4`} onClick={() => handleCopyBtnClickClientSecret(currentGameType?.clientSecret)}>{hasCopiedClientSecret ? <AiOutlineCheck color="green"/> : <AiOutlineCopy/>}</span>

--- a/src/ui/AddEnemyToFloorModal/AddEnemyToFloorModal.tsx
+++ b/src/ui/AddEnemyToFloorModal/AddEnemyToFloorModal.tsx
@@ -69,6 +69,7 @@ const AddEnemyToFloorModal = ({
                                     <span
                                         className="cursor-pointer"
                                         onClick={handleOnAddEnemyClick(enemy)}
+                                        key={enemy.id}
                                     >
                                         {emojiToImageTag(
                                             enemy.emoji,
@@ -92,6 +93,7 @@ const AddEnemyToFloorModal = ({
                                         onClick={handleOnRemoveEnemyClick(
                                             enemy
                                         )}
+                                        key={enemy.id}
                                     >
                                         {emojiToImageTag(
                                             enemy.emoji,

--- a/src/ui/AddEnemyToFloorModal/AddEnemyToFloorModal.tsx
+++ b/src/ui/AddEnemyToFloorModal/AddEnemyToFloorModal.tsx
@@ -1,5 +1,6 @@
 import { groupBy } from "lodash";
 import { useEffect, useState } from "react";
+import { AiOutlineDelete } from "react-icons/ai";
 import { updateFloor } from "../../api/admin";
 import { emojiToImageTag } from "../../helpers/emojiHelper";
 import Button from "../Button";
@@ -22,14 +23,14 @@ const AddEnemyToFloorModal = ({
 }: IProps) => {
     const [floorEnemies, setFloorEnemies] = useState<IEnemy[]>([]);
 
-    const handleOnSaveButtonClick = () => {
+    const handleOnSaveButtonClick = async () => {
         const floorId = floor?.id;
         const enemyIds = floorEnemies.map((enemy) => enemy.id) as number[];
 
         if (!floorId || !enemyIds) {
             return;
         }
-        updateFloor(floorId, {
+        await updateFloor(floorId, {
             enemyIds,
         });
         onClose(true);
@@ -97,7 +98,7 @@ const AddEnemyToFloorModal = ({
                             })}
                         </div>
                     </div>
-                    <div className="w-full bg-green-500">
+                    <div className="w-full bg-green-500 relative">
                         <p className="text-xl text-white text-center mb-4 uppercase">
                             Floor Enemies
                         </p>
@@ -117,6 +118,7 @@ const AddEnemyToFloorModal = ({
                                 </span>
                             ))}
                         </div>
+                        <span className="absolute cursor-pointer bottom-2 left-1/2 hover:text-xteamaccent" onClick={() => setFloorEnemies([])}><AiOutlineDelete /></span>
                     </div>
                 </div>
 


### PR DESCRIPTION
Design improvements for Floors Page + Fixing the behavior issues

Ticket:
https://x-team-internal.atlassian.net/browse/XTG-291

Big Res
<img width="1723" alt="image" src="https://user-images.githubusercontent.com/790844/177662349-4cd6741f-bd40-4559-ae66-95b70a98e9c1.png">

Small Res
<img width="857" alt="image" src="https://user-images.githubusercontent.com/790844/177662323-db4f2fdf-3cc4-41b6-a7c0-e9c05be832b5.png">

Modal:
<img width="1697" alt="image" src="https://user-images.githubusercontent.com/790844/177662383-b80e2f2e-59fa-4f52-82eb-ce8f0c62e7b4.png">

Modal Update: Added a 🗑 button to delete all enemies:
<img width="1082" alt="image" src="https://user-images.githubusercontent.com/790844/177790228-0240406a-bb00-4d03-9695-7bf966e8f047.png">
