### PR TITLE
fix contract with getState

### DIFF
--- a/src/pages/InspectArenaPage.tsx
+++ b/src/pages/InspectArenaPage.tsx
@@ -19,7 +19,7 @@ const InspectArenaPage = function InspectArenaPage(props: any) {
 
     const arenaPlayers = get(
         arenaGame,
-        "_arena._players",
+        "_arenaPlayers",
         []
     ) as IArenaPlayer[];
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -167,6 +167,7 @@ interface IGame {
   endedAt: string;
   _gameTypeId: number;
   _arena: IArenaGame;
+  _arenaPlayers: [IArenaPlayer];
 }
 
 interface IGameWithTower extends IGame {
@@ -181,7 +182,7 @@ interface IArenaGame {
   currentRingDeactivation: number;
   inactiveZonePenaltyPower: number;
   _gameId: number;
-  _players: [IArenaPlayer];
+
 }
 
 interface IArenaRoundAction {


### PR DESCRIPTION
players were not being listed
fix on contract change on the getState endpoint

![image](https://user-images.githubusercontent.com/8170617/180497463-b0631c51-320d-423a-b0ea-7a56c3d965ca.png)
