### PR TITLE
[FIX] - XTG-379 - Inspect Arena Cards

### DIFF
--- a/src/helpers/emojiHelper.tsx
+++ b/src/helpers/emojiHelper.tsx
@@ -68,10 +68,11 @@ const emojiToImageSrcMap: { [id: string]: string } = {
 };
 
 export const emojiToImageSrc = (emoji: string, allEmoji: IAllEmoji) => {
-    if (allEmoji[emoji]) {
-        return allEmoji[emoji];
+    let formattedEmoji = emoji.substring(1, emoji.length - 1);
+    if (allEmoji[formattedEmoji]) {
+        return allEmoji[formattedEmoji];
     }
-
+    
     return (
         emojiToImageSrcMap[emoji] ||
         "https://via.placeholder.com/128x128"

--- a/src/helpers/emojiHelper.tsx
+++ b/src/helpers/emojiHelper.tsx
@@ -6,6 +6,12 @@ const emojiToImageSrcMap: { [id: string]: string } = {
         "https://emoji.slack-edge.com/T0257R0RP/corgi/97ece3358f9f36fa.png",
     ":ragnar:":
         "https://emoji.slack-edge.com/T0257R0RP/ragnar/04e25e482cac6f41.png",
+    ":nascentfire:":
+        "https://emoji.slack-edge.com/T0257R0RP/nascent-fire/a68fb251a226ffa0.png",
+    ":lions-pride:":
+        "https://emoji.slack-edge.com/T0257R0RP/lions-pride/3fd84234325db483.png",
+    ":pandablob:":
+        "https://emoji.slack-edge.com/T0257R0RP/pandablob/7086d4fa683ea539.png",
 
     // WEAPONS
     ":rc06-envisioner:":
@@ -27,6 +33,20 @@ const emojiToImageSrcMap: { [id: string]: string } = {
         "https://emoji.slack-edge.com/T0257R0RP/flare-blasters-m21/1c256e330d689818.png",
     ":kobol's-thunderbolt:":
         "https://emoji.slack-edge.com/T0257R0RP/kobol%2527s-thunderbolt/dbf4814ca8141671.png",
+    ":cetraah's-firehawk:": 
+        "https://emoji.slack-edge.com/T0257R0RP/cetraah%2527s-firehawk/a5d8cb1a8899627b.png",
+    ":dmitrevna's-shotgun:":
+        "https://emoji.slack-edge.com/T0257R0RP/kade%2527s-dualpistols/bcdf7da6e0cffdeb.png",
+    ":kade's-dualpistols:":
+        "https://emoji.slack-edge.com/T0257R0RP/dmitrevna%2527s-shotgun/49abddfecad3820c.png",
+    ":pyro's-doublebarrel:":
+        "https://emoji.slack-edge.com/T0257R0RP/pyro%2527s-doublebarrel/e646382817f08734.png",
+    ":flamer's-firestarters:":
+        "https://emoji.slack-edge.com/T0257R0RP/flamer%2527s-firestarters/47a6b91eed78a86b.png",
+    ":cetraah's-executioner:":
+        "https://emoji.slack-edge.com/T0257R0RP/cetraah%2527s-executioner/a7314dd157b58360.png",
+    ":hellfire-shotgun:":
+        "https://emoji.slack-edge.com/T0257R0RP/hellfire-shotgun/07daccd70d9df07f.png",
 
     // ARMOR
     ":arena-armor-common:":
@@ -37,8 +57,6 @@ const emojiToImageSrcMap: { [id: string]: string } = {
         "https://emoji.slack-edge.com/T0257R0RP/arena-armor-epic/b6f60908f7d1f2c6.png",
     ":arena-armor-legendary:":
         "https://emoji.slack-edge.com/T0257R0RP/arena-armor-legendary/07e16ef899796139.png",
-    ":kade's-dualpistols:":
-        "https://emoji.slack-edge.com/T0257R0RP/kade%2527s-dualpistols/bcdf7da6e0cffdeb.png",
 
     // UI
     ":health-heart:":
@@ -50,13 +68,12 @@ const emojiToImageSrcMap: { [id: string]: string } = {
 };
 
 export const emojiToImageSrc = (emoji: string, allEmoji: IAllEmoji) => {
-    let formattedEmoji = emoji.substring(1, emoji.length - 1);
-    if (allEmoji[formattedEmoji]) {
-        return allEmoji[formattedEmoji];
+    if (allEmoji[emoji]) {
+        return allEmoji[emoji];
     }
 
     return (
-        emojiToImageSrcMap[formattedEmoji] ||
+        emojiToImageSrcMap[emoji] ||
         "https://via.placeholder.com/128x128"
     );
 };
@@ -76,5 +93,21 @@ export const emojiToImageTag = (
             />
             {qty && <div className="rounded-full border-2 border-xteamaccent bg-xteamaccent p-0 w-7 scale-[0.6] translate-x-6 -translate-y-3"><span className="text-md text-white">{qty}</span></div>}
         </div>
+    );
+};
+
+
+
+export const emojiToImageLabel = (
+    emoji: string,
+    allEmoji: IAllEmoji,
+    className?: string
+) => {
+    return (
+        <img
+            className={`inline ${className || `h-6 w-6`}`}
+            src={emojiToImageSrc(emoji, allEmoji)}
+            alt={emoji + " emoji"}
+        />
     );
 };

--- a/src/pages/InspectArenaPage.tsx
+++ b/src/pages/InspectArenaPage.tsx
@@ -50,9 +50,9 @@ const InspectArenaPage = function InspectArenaPage(props: any) {
                     </div>
 
                     <div className="flex flex-wrap">
-                        {arenaPlayers.map((player, index) => (
+                        {arenaPlayers.map((player) => (
                             <InspectArenaPlayerCard
-                                key={index}
+                                key={player._userId}
                                 player={player}
                             />
                         ))}

--- a/src/pages/ListWeaponsPage.tsx
+++ b/src/pages/ListWeaponsPage.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { SyncLoader } from "react-spinners";
 import Swal from "sweetalert2";
 import { deleteWeapon, getWeapons } from "../api/admin";
-import { emojiToImageTag } from "../helpers/emojiHelper";
+import { emojiToImageLabel } from "../helpers/emojiHelper";
 import { rarityToTextColor } from "../helpers/rarityHelper";
 import Button from "../ui/Button";
 
@@ -87,7 +87,7 @@ const ListWeaponsPage = function ListWeaponsPage(props: any) {
                   >
                     <div className="flex">
                       <div>
-                        {emojiToImageTag(weapon.emoji, {}, "h-12 w-12")}
+                        {emojiToImageLabel(weapon.emoji, {}, "h-12 w-12")}
                       </div>
                       <div className={`ml-2 flex flex-col`}>
                         <span>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -109,6 +109,7 @@ interface IWeapon {
   emoji: string;
   usageLimit: number | null;
   isArchived: boolean;
+  type?: string;
   _itemRarityId: TArenaRarity;
   _weapon: IWeaponData;
   _traits: ITrait[];

--- a/src/ui/InspectArenaPlayerCard/InspectArenaPlayerCard.tsx
+++ b/src/ui/InspectArenaPlayerCard/InspectArenaPlayerCard.tsx
@@ -1,4 +1,5 @@
-import { emojiToImageTag } from "../../helpers/emojiHelper";
+import React from "react";
+import { emojiToImageLabel } from "../../helpers/emojiHelper";
 import { truncateText } from "../../helpers/textHelper";
 
 interface IProps {
@@ -8,6 +9,10 @@ interface IProps {
 const InspectArenaPlayerCard = function InspectArenaPlayerCard({
     player,
 }: IProps) {
+    const medKits = player._weapons.filter(item => item.type === 'medical kit');
+    const armors = player._weapons.filter(item => item.type === 'armor');
+    const weapons = player._weapons.filter(item => item.type === 'weapon');
+
     return (
         <span className="mr-2 mb-2">
             <div
@@ -16,22 +21,22 @@ const InspectArenaPlayerCard = function InspectArenaPlayerCard({
                 }`}
             >
                 <div className="flex">
-                    <div className="w-24 flex flex-col justify-center items-center">
+                    <div className="w-32 flex flex-col justify-center items-center">
                         <img
                             className="w-12 h-12 rounded-full mb-1 "
                             src={player._user.profilePictureUrl}
-                            alt={player._user.displayName}
+                            alt={`${player._user.displayName}'s profile`}
                         />
                         <div className="font-semibold text-center">
-                            {truncateText(player._user.displayName, 9)}
+                            {truncateText(player._user.displayName, 16)}
                         </div>
                         <div className="font-semibold text-lg text-center flex justify-center items-center">
-                            {emojiToImageTag(":health-heart:", {}, "w-4 h-4")}
+                            {emojiToImageLabel(":health-heart:", {}, "w-4 h-4")}
                             <span className="text-base ml-1">
                                 {player.health}
                             </span>
-                            {emojiToImageTag(
-                                ":arena-armor-epic:",
+                            {armors && armors.length > 0 && emojiToImageLabel(
+                                armors.length === 1 ? armors[0].emoji : ":arena-armor-rare:",
                                 {},
                                 "h-5 w-5 ml-2"
                             )}
@@ -39,12 +44,12 @@ const InspectArenaPlayerCard = function InspectArenaPlayerCard({
 
                         <span className="thin font-sans text-center flex items-center justify-center mt-1 gap-1">
                             <span className="flex items-center">
-                                <span className="mr-1">4</span>
-                                {emojiToImageTag(":medkit:", {}, "h-5 w-5")}
+                                <span className="mr-1">{medKits.length}</span>
+                                {emojiToImageLabel(":medkit:", {}, "h-5 w-5")}
                             </span>
                             <span className="flex items-center">
                                 <span className="mr-1">112</span>
-                                {emojiToImageTag(":cheer-star:", {}, "h-5 w-5")}
+                                {emojiToImageLabel(":cheer-star:", {}, "h-5 w-5")}
                             </span>
                         </span>
                     </div>
@@ -53,8 +58,8 @@ const InspectArenaPlayerCard = function InspectArenaPlayerCard({
                         <div className="relative h-full flex flex-col">
                             <div className="absolute mt-2">
                                 <span className="text-gray-400 thin font-sans text-center flex justify-center items-center mb-2 opacity-5">
-                                    {emojiToImageTag(
-                                        ":corgi:",
+                                    {emojiToImageLabel(
+                                        player?._team?.emoji || ":corgi:",
                                         {},
                                         "h-32 w-32"
                                     )}
@@ -63,8 +68,10 @@ const InspectArenaPlayerCard = function InspectArenaPlayerCard({
 
                             <span className="text-gray-400 thin font-sans text-center flex ml-4">
                                 <div className="mt-2 flex flex-wrap">
-                                    {player._weapons.map((weapon) =>
-                                        emojiToImageTag(weapon.emoji, {})
+                                    {weapons.map((weapon) =>
+                                        <React.Fragment key={weapon.id}>
+                                            {emojiToImageLabel(weapon.emoji, {})}
+                                        </React.Fragment>
                                     )}
                                 </div>
                             </span>


### PR DESCRIPTION
This PR fixes the inspect arena card, except for the cheer count, which I had not enough time to change the API to create a relationship between `ArenaPlayer` and `ArenaPlayerPerformance` models. 

Ticket Link:
https://x-team-internal.atlassian.net/browse/XTG-379